### PR TITLE
SHARC-212 Update rubocop exclude inheritance

### DIFF
--- a/panolint-rails-rubocop.yml
+++ b/panolint-rails-rubocop.yml
@@ -15,7 +15,13 @@ require:
   - rubocop-rails
   - rubocop-rspec
 
+# This `inherit_mode` merges this repo's "Exclude" list with the list from
+# `panolint-ruby`, which this config inherits from. When a repo uses this gem,
+# and inherits from this config, it then inherits the merged exclusions list.
 AllCops:
+  inherit_mode:
+      merge:
+        - Exclude
   Exclude:
     - "db/schema.rb"
     - "db/migrate/**/*"


### PR DESCRIPTION
The `inherit_mode` merge type "Exclude" allows this repo to inherit the [excluded files list](https://github.com/panorama-ed/panolint-ruby/blob/22a953483885ff54e78256dc939f60ba4a951895/panolint-ruby-rubocop.yml#L15) from `panolint-ruby` since this config inherits from that `.rubocop.yml` file. This is necessary because files that aren't required for rubocop to pass locally (e.g. the vendor files specified [here](https://github.com/panorama-ed/panolint-ruby/blob/22a953483885ff54e78256dc939f60ba4a951895/panolint-ruby-rubocop.yml#L16C21-L16C21)) can fail to pass rubocop when tests run in the CI pipeline. We want to ensure that repos using this gem have consistent sets of files excluded, though more can be added to the defaults. In NDS, we also merge in additional exclusions [here](https://github.com/panorama-ed/nds/blob/2586e8b5bd32f2d4865228305721f5a68967db7a/.rubocop.yml#L13).

Testing:
- [x] Tested with the `metrics-recorder` repo, which is still currently using the old panolint gem. To test, I updated the repo to install this gem from this specific branch, as well as `panolint-ruby` (from the "main" branch). I bundle installed, ran local tests for the repo, ran rubocop locally, then also pushed a build to CI to ensure it passed (it did pass, which it did not when using the "main" branch of the `panolint-rails` gem without merging the exclude list in metrics-recorder's rubocop.yml file). 
- [x] Tested with `nds`, which is the only repo currently using this gem. I updated NDS to pull from this branch and bundle installed overcommit gems. Confirmed it pulled using this branch and then I ran rubocop. The same violations appeared there as with the "main" branch.

