### PR TITLE
SECZ-1715: Add Rails/LinkToBlank

### DIFF
--- a/panolint-rails-rubocop.yml
+++ b/panolint-rails-rubocop.yml
@@ -27,5 +27,11 @@ AllCops:
     - "db/migrate/**/*"
   NewCops: enable
 
+# This mitigates this vulnerability:
+# https://owasp.org/www-community/attacks/Reverse_Tabnabbing
+# While this is resolved in modern browsers, not all users have modern browsers
+Rails/LinkToBlank:
+  Enabled: true
+
 Rails/I18nLocaleTexts:
   Enabled: false


### PR DESCRIPTION
Mitigation for reverse tabnapping. This risk is mitigated in modern browsers (e.g. Chrome > 88), but not all users have modern browsers. For more information, please reach out internally to Security.