### PR TITLE
IOPZ-3660 Add rubocop-rspec_rails gem dependency

### DIFF
--- a/panolint-rails-rubocop.yml
+++ b/panolint-rails-rubocop.yml
@@ -14,6 +14,7 @@ require:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-rspec_rails
 
 # This `inherit_mode` merges this repo's "Exclude" list with the list from
 # `panolint-ruby`, which this config inherits from. When a repo uses this gem,

--- a/panolint-rails.gemspec
+++ b/panolint-rails.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "brakeman", "7.0.0"
   spec.add_dependency "rubocop-rails", "2.29.1"
+  spec.add_dependency "rubocop-rspec_rails", "2.30.0"
 end


### PR DESCRIPTION
This commit adds the `rubocop-rspec_rails` gem dependency, to resolve downstream inconsistencies and errors caused by some repos that use this gem explicitly loading and requiring the `rubocop-rspec_rails` gem while others were not.