### PR TITLE
SECZ-2497: Move to plugins

### DIFF
--- a/panolint-rails-rubocop.yml
+++ b/panolint-rails-rubocop.yml
@@ -10,10 +10,8 @@
 inherit_gem:
   panolint-ruby: panolint-ruby-rubocop.yml
 
-require:
-  - rubocop-performance
+plugins:
   - rubocop-rails
-  - rubocop-rspec
   - rubocop-rspec_rails
 
 # This `inherit_mode` merges this repo's "Exclude" list with the list from


### PR DESCRIPTION
Resolving the following warnings:

```
rubocop-rails extension supports plugin, specify `plugins: rubocop-rails` instead of `require: rubocop-rails` in /<path>/panolint-rails-rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in /<path>/panolint-rails-rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
rubocop-rspec_rails extension supports plugin, specify `plugins: rubocop-rspec_rails` instead of `require: rubocop-rspec_rails` in /<path>/panolint-rails-rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in /<path>/panolint-ruby-rubocop.yml.
```

Performance also supports this: https://github.com/rubocop/rubocop-performance/