### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot-prs.yml
+++ b/.github/workflows/dependabot-prs.yml
@@ -1,4 +1,7 @@
 name: Dependabot Pull Request
+permissions:
+  contents: read
+  pull-requests: write
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,7 @@
 name: Main
 on: push
+permissions:
+  contents: read
 jobs:
   ci:
     name: CI


### PR DESCRIPTION
Potential fix for [https://github.com/panorama-ed/panolint-rails/security/code-scanning/2](https://github.com/panorama-ed/panolint-rails/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow interacts with pull requests and uses the `gh` CLI for operations like merging and reviewing, the minimal required permissions are likely `contents: read` and `pull-requests: write`. 

The `permissions` block should be added at the root level of the workflow to apply to all jobs unless overridden. This ensures that the `GITHUB_TOKEN` has only the necessary permissions for the workflow's operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
