### PR TITLE
SECOPS-523: Update dependabot bake time, and gem file bake time.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
 - package-ecosystem: bundler
   directory: "/"
+  cooldown:
+    default-days: 7
   schedule:
     interval: weekly
     time: "00:00"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source "https://rubygems.org", cooldown: 6
 
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 


### PR DESCRIPTION
Update Dependabot bake time, and gem file bake time. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk dependency tooling/configuration change with no application runtime logic changes.
> 
> **Overview**
> Adds a **7-day Dependabot cooldown** for Bundler updates in `.github/dependabot.yml`, delaying dependency PRs after new releases.
> 
> Also adds a `cooldown: 6` option to the RubyGems source in `Gemfile`, aligning dependency update bake-time configuration at the Gemfile level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 561a4f0926771d2a37a78a7a34154e9bb11aa641. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->